### PR TITLE
Surround filenames with quotes in trivial-copy-copy-fn of darwin

### DIFF
--- a/trivial-copy.el
+++ b/trivial-copy.el
@@ -27,7 +27,8 @@
 (defvar trivial-copy-copy-fn-alist '((darwin . (lambda (file-list)
                                                  (shell-command-to-string
                                                   (string-join
-                                                   (append (list trivial-copy-mac-copy-exe) file-list)
+                                                   (append (list trivial-copy-mac-copy-exe)
+                                                           (mapcar (lambda (file) (format "\"%s\"" file)) file-list))
                                                    " "))))
                                      (gnu/linux . trivial-copy-linux-copy))
   "An alist of copy functions. (system-symbol . function)


### PR DESCRIPTION
Hi, thanks for your work. However, I have noticed that when there are whitespaces in the filename, it doesn't work.

For example, I have a file named `/Users/xxx/Desktop/gpu [Wiki Wiki].pdf`. When I run `trivial-copy-copy`, zsh gives me an error. 

```bash
"zsh:1: bad pattern: [Wiki
"
```

So I surround filenames with extra quotes. ;)